### PR TITLE
Rebase original commits for #132 and review changes for SPR-9692, SPR-9566

### DIFF
--- a/spring-expression/src/test/java/org/springframework/expression/spel/MethodInvocationTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/MethodInvocationTests.java
@@ -29,6 +29,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.expression.AccessException;
+import org.springframework.expression.BeanResolver;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
 import org.springframework.expression.ExpressionInvocationTargetException;
@@ -44,6 +45,7 @@ import org.springframework.expression.spel.testresources.PlaceOfBirth;
  * Tests invocation of methods.
  *
  * @author Andy Clement
+ * @author Phillip Webb
  */
 public class MethodInvocationTests extends ExpressionTestCase {
 
@@ -368,5 +370,30 @@ public class MethodInvocationTests extends ExpressionTestCase {
 		Expression expression = parser.parseExpression("getName()");
 		Object value = expression.getValue(new StandardEvaluationContext(String.class));
 		assertEquals(value, "java.lang.String");
+	}
+
+	@Test
+	public void invokeMethodWithoutConversion() throws Exception {
+		final BytesService service = new BytesService();
+		byte[] bytes = new byte[100];
+		StandardEvaluationContext context = new StandardEvaluationContext(bytes);
+		context.setBeanResolver(new BeanResolver() {
+			public Object resolve(EvaluationContext context, String beanName)
+					throws AccessException {
+				if("service".equals(beanName)) {
+					return service;
+				}
+				return null;
+			}
+		});
+		Expression expression = parser.parseExpression("@service.handleBytes(#root)");
+		byte[] outBytes = expression.getValue(context, byte[].class);
+		assertSame(bytes, outBytes);
+	}
+
+	public static class BytesService {
+		public byte[] handleBytes(byte[] bytes) {
+			return bytes;
+		}
 	}
 }


### PR DESCRIPTION
Phil,

A few things to review:
- The use of ExpectedException causes `NoSuchMethodErrors` for me under both Eclipse and Gradle. Presumably you're getting different results? Please run tests like `TypeDescriptorTests` to confirm, and let's figure out how to make everything work.
- `TypeDescriptor` has been made final - why? What do you think the likelihood is of this being a breaking change for people, i.e. how likely is it that folks might have extended this type?
- #132 contains commits for both SPR-9566 and SPR-9692 - why, i.e. what is the relationship between these two, i.e. why combine both in a single PR?
- both SPR-9566 and SPR-9692 have their fixVersion set for both 3.1.3 and 3.2 RC1. Given the scope of these changes, I am hesitant to backport them to 3.1.3 (still need to understand the complete impact even to 3.2). Do you have a strong case for backporting one or both?
- It appears that these changes modify the conversion algorithm to match superclasses with a higher precedence than interfaces. As per your comments in SPR-9692, this would seem to introduce a backward-compatibility problem. Do you have a rationale as to why this change is merited, i.e. that the previous behavior is simply wrong, that it is very unlikely to actually affect anyone, etc.?

In any case, this pull request rebases your commits against the latest from SpringSource/master and fixes the conflicts that cropped up along the way. As usual, just do a non-ff merge of this PR and we'll see #132 automatically update. We can continue the conversation there.

Thanks!
